### PR TITLE
adding benchmark to fab attack branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We ask that you follow the `PEP8` coding style in your pull requests, [`flake8`]
 - *(mandatory)* The implementation file should be added to the folder `advertorch/attacks`, and the class should be imported in `advertorch/attacks/__init__.py`.
 - *(mandatory)* The attack should be included in different unit tests, this can be done by adding the attack class to different lists in `advertorch/test_utils.py`
     + add to `general_input_attacks` if it can perturb input tensor of any shape (not limited to images),
-    + add to `image_only_attacks` if it specifically work on images,
+    + add to `image_only_attacks` if it only works on images,
     + add to `label_attacks` if the attack manipulates labels,
     + add to `feature_attacks` if the attack manipulates features,
     + add to `batch_consistent_attacks` if the attack's behavior should be the same when it is applied to a single example or a batch,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to AdverTorch
+
+Thank you considering contributing to AdverTorch!
+
+This document provide brief guidelines for potential contributors.
+
+Please use pull requests for new features, bug fixes, new examples and etc. If you work on something with significant efforts, please mention it in early stage using issues.
+
+We ask that you follow the `PEP8` coding style in your pull requests, [`flake8`](http://flake8.pycqa.org/) is used in continuous integration to enforce this.
+
+---
+### Detailed guidelines for contributing new attacks
+- *(mandatory)* The implementation file should be added to the folder `advertorch/attacks`, and the class should be imported in `advertorch/attacks/__init__.py`.
+- *(mandatory)* The attack should be included in different unit tests, this can be done by adding the attack class to different lists in `advertorch/test_utils.py`
+    + add to `general_input_attacks` if it can perturb input tensor of any shape (not limited to images),
+    + add to `image_only_attacks` if it specifically work on images,
+    + add to `label_attacks` if the attack manipulates labels,
+    + add to `feature_attacks` if the attack manipulates features,
+    + add to `batch_consistent_attacks` if the attack's behavior should be the same when it is applied to a single example or a batch,
+    + add to `targeted_only_attacks` if the attack is a label attack and does not work for the untargeted case,
+    + add entry to `attack_kwargs` in `advertorch/tests/test_attacks_running.py`, for setting the hyperparameters used for test.
+- *(mandatory)* Benchmark the attack with at least one performance measure, by adding a script to `advertorch_examples/attack_benchmarks`.
+- *(mandatory)* If the contributor has a GPU computer, run `pytest` locally to make sure all the tests pass. (This is because travis-ci currently do not provide GPU machines for continuous integration.) If the contributor does not have a GPU computer, please let us know in the pull request. 
+- *(optional)* When an attack can be compared against other implementations, a comparison test could be added to `advertorch/external_tests`.
+- *(optional)* Add an ipython notebook example.
+
+---
+### Copyright notice at the beginning of files
+
+For files purely contributed by contributors outside of RBC, the following lines should appear at the beginning
+```
+# Copyright (c) 2019-present, Name of the Contributor.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+```
+
+For files involving both RBC employees and 
+contributors outside of RBC, the following lines should appear at the beginning
+```
+# Copyright (c) 2018-present, Royal Bank of Canada and other authors.
+# See the AUTHORS.txt file for a list of contributors.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+```

--- a/advertorch/attacks/utils.py
+++ b/advertorch/attacks/utils.py
@@ -48,7 +48,8 @@ def rand_init_delta(delta, x, ord, eps, clip_min, clip_max):
         delta.data = delta.data - x
         delta.data = clamp_by_pnorm(delta.data, ord, eps)
     elif ord == 1:
-        ini = laplace.Laplace(0, 1)
+        ini = laplace.Laplace(
+            loc=delta.new_tensor(0), scale=delta.new_tensor(1))
         delta.data = ini.sample(delta.data.shape)
         delta.data = normalize_by_pnorm(delta.data, p=1)
         ray = uniform.Uniform(0, eps).sample()

--- a/advertorch_examples/attack_benchmarks/benchmark_decoupled_direction_norm.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_decoupled_direction_norm.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2018-present, Royal Bank of Canada and other authors.
+# See the AUTHORS.txt file for a list of contributors.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from advertorch_examples.utils import get_mnist_test_loader
+from advertorch_examples.utils import get_mnist_lenet5_clntrained
+from advertorch_examples.utils import get_mnist_lenet5_advtrained
+from advertorch_examples.benchmark_utils import get_benchmark_sys_info
+
+from advertorch.attacks import DDNL2Attack
+
+from advertorch_examples.benchmark_utils import benchmark_margin
+
+batch_size = 100
+device = "cuda"
+
+lst_attack = [
+    (DDNL2Attack, dict(
+        nb_iter=1000, gamma=0.05, init_norm=1., quantize=True, levels=256,
+        clip_min=0., clip_max=1., targeted=False)),
+]  # each element in the list is the tuple (attack_class, attack_kwargs)
+
+mnist_clntrained_model = get_mnist_lenet5_clntrained().to(device)
+mnist_advtrained_model = get_mnist_lenet5_advtrained().to(device)
+mnist_test_loader = get_mnist_test_loader(batch_size=batch_size)
+
+lst_setting = [
+    (mnist_clntrained_model, mnist_test_loader),
+    (mnist_advtrained_model, mnist_test_loader),
+]
+
+
+info = get_benchmark_sys_info()
+
+lst_benchmark = []
+for model, loader in lst_setting:
+    for attack_class, attack_kwargs in lst_attack:
+        lst_benchmark.append(benchmark_margin(
+            model, loader, attack_class, attack_kwargs, 2))
+
+print(info)
+for item in lst_benchmark:
+    print(item)

--- a/advertorch_examples/attack_benchmarks/benchmark_decoupled_direction_norm.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_decoupled_direction_norm.py
@@ -5,6 +5,59 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 #
+#
+#
+# Automatically generated benchmark report (screen print of running this file)
+#
+# sysname: Linux
+# release: 4.4.0-140-generic
+# version: #166-Ubuntu SMP Wed Nov 14 20:09:47 UTC 2018
+# machine: x86_64
+# python: 3.7.3
+# torch: 1.1.0
+# torchvision: 0.3.0
+# advertorch: 0.1.5
+
+# attack type: DDNL2Attack
+# attack kwargs: nb_iter=1000
+#                gamma=0.05
+#                init_norm=1.0
+#                quantize=True
+#                levels=256
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test
+# model: MNIST LeNet5 standard training
+# accuracy: 98.89%
+# attack success rate: 100.0%
+# Among successful attacks (L2 norm):
+#    minimum distance: 0.0
+#    median distance: 1.382
+#    maximum distance: 3.3
+#    average distance: 1.365
+#    distance standard deviation: 0.4907
+
+# attack type: DDNL2Attack
+# attack kwargs: nb_iter=1000
+#                gamma=0.05
+#                init_norm=1.0
+#                quantize=True
+#                levels=256
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
+# accuracy: 98.64%
+# attack success rate: 100.0%
+# Among successful attacks (L2 norm):
+#    minimum distance: 0.0
+#    median distance: 1.861
+#    maximum distance: 20.45
+#    average distance: 1.891
+#    distance standard deviation: 0.7611
+
 
 from advertorch_examples.utils import get_mnist_test_loader
 from advertorch_examples.utils import get_mnist_lenet5_clntrained

--- a/advertorch_examples/attack_benchmarks/benchmark_decoupled_direction_norm.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_decoupled_direction_norm.py
@@ -31,12 +31,12 @@
 # model: MNIST LeNet5 standard training
 # accuracy: 98.89%
 # attack success rate: 100.0%
-# Among successful attacks (L2 norm):
-#    minimum distance: 0.0
-#    median distance: 1.382
+# Among successful attacks (L2 norm) on correctly classified examples:
+#    minimum distance: 0.006792
+#    median distance: 1.388
 #    maximum distance: 3.3
-#    average distance: 1.365
-#    distance standard deviation: 0.4907
+#    average distance: 1.38
+#    distance standard deviation: 0.4716
 
 # attack type: DDNL2Attack
 # attack kwargs: nb_iter=1000
@@ -51,12 +51,12 @@
 # model: MNIST LeNet 5 PGD training according to Madry et al. 2018
 # accuracy: 98.64%
 # attack success rate: 100.0%
-# Among successful attacks (L2 norm):
-#    minimum distance: 0.0
-#    median distance: 1.861
+# Among successful attacks (L2 norm) on correctly classified examples:
+#    minimum distance: 0.005546
+#    median distance: 1.872
 #    maximum distance: 20.45
-#    average distance: 1.891
-#    distance standard deviation: 0.7611
+#    average distance: 1.917
+#    distance standard deviation: 0.733
 
 
 from advertorch_examples.utils import get_mnist_test_loader

--- a/advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2018-present, Royal Bank of Canada and other authors.
+# See the AUTHORS.txt file for a list of contributors.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#
+#
+# Automatically generated benchmark report (screen print of running this file)
+#
+# sysname: Linux
+# release: 4.4.0-140-generic
+# version: #166-Ubuntu SMP Wed Nov 14 20:09:47 UTC 2018
+# machine: x86_64
+# python: 3.7.3
+# torch: 1.1.0
+# torchvision: 0.3.0
+# advertorch: 0.1.5
+
+# attack type: FABAttack
+# attack kwargs: norm=Linf
+#                n_restarts=1
+#                n_iter=20
+#                eps=-1
+#                alpha_max=0.1
+#                eta=1.05
+#                beta=0.9
+#                device=none
+#                loss_fn=none
+# data: mnist_test
+# model: MNIST LeNet5 standard training
+# accuracy: 98.89%
+# attack success rate: 100.0%
+# Among successful attacks (Linf norm) on correctly classified examples:
+#    minimum distance: 0.0001394
+#    median distance: 0.112
+#    maximum distance: 0.2157
+#    average distance: 0.1092
+#    distance standard deviation: 0.03498
+
+# attack type: FABAttack
+# attack kwargs: norm=Linf
+#                n_restarts=1
+#                n_iter=20
+#                eps=-1
+#                alpha_max=0.1
+#                eta=1.05
+#                beta=0.9
+#                device=none
+#                loss_fn=none
+# data: mnist_test
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
+# accuracy: 98.64%
+# attack success rate: 99.83%
+# Among successful attacks (Linf norm) on correctly classified examples:
+#    minimum distance: 0.001405
+#    median distance: 0.3509
+#    maximum distance: 0.6277
+#    average distance: 0.3477
+#    distance standard deviation: 0.05234
+
+
+from advertorch_examples.utils import get_mnist_test_loader
+from advertorch_examples.utils import get_mnist_lenet5_clntrained
+from advertorch_examples.utils import get_mnist_lenet5_advtrained
+from advertorch_examples.benchmark_utils import get_benchmark_sys_info
+
+from advertorch.attacks import FABAttack
+
+from advertorch_examples.benchmark_utils import benchmark_margin
+
+batch_size = 100
+device = "cuda"
+
+lst_attack = [
+    (FABAttack, dict(
+        norm='Linf',
+        n_restarts=1,
+        n_iter=20,
+        eps=-1,
+        alpha_max=0.1,
+        eta=1.05,
+        beta=0.9,
+        device='none',
+        loss_fn='none')),
+]  # each element in the list is the tuple (attack_class, attack_kwargs)
+
+mnist_clntrained_model = get_mnist_lenet5_clntrained().to(device)
+mnist_advtrained_model = get_mnist_lenet5_advtrained().to(device)
+mnist_test_loader = get_mnist_test_loader(batch_size=batch_size)
+
+lst_setting = [
+    (mnist_clntrained_model, mnist_test_loader),
+    (mnist_advtrained_model, mnist_test_loader),
+]
+
+
+info = get_benchmark_sys_info()
+
+lst_benchmark = []
+for model, loader in lst_setting:
+    for attack_class, attack_kwargs in lst_attack:
+        lst_benchmark.append(benchmark_margin(
+            model, loader, attack_class, attack_kwargs, norm="inf"))
+
+print(info)
+for item in lst_benchmark:
+    print(item)

--- a/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
@@ -28,7 +28,7 @@
 #                clip_max=1.0
 #                targeted=False
 # data: mnist_test
-# model: mnist_lenet5_clntrained
+# model: MNIST LeNet5 standard training
 # accuracy: 98.89%
 # attack success rate: 100.0%
 
@@ -42,10 +42,9 @@
 #                clip_max=1.0
 #                targeted=False
 # data: mnist_test
-# model: mnist_lenet5_advtrained
+# model: MNIST LeNet 5 PGD training according to Madry et al. 2018
 # accuracy: 98.64%
 # attack success rate: 6.8%
-
 
 
 import torch.nn as nn

--- a/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
@@ -20,31 +20,32 @@
 
 # attack type: LinfPGDAttack
 # attack kwargs: loss_fn=CrossEntropyLoss()
-#                eps=0.15
+#                eps=0.3
 #                nb_iter=40
 #                eps_iter=0.01
-#                rand_init=True
+#                rand_init=False
 #                clip_min=0.0
 #                clip_max=1.0
 #                targeted=False
 # data: mnist_test
 # model: mnist_lenet5_clntrained
 # accuracy: 98.89%
-# robust accuracy: 8.9%
+# attack success rate: 100.0%
 
 # attack type: LinfPGDAttack
 # attack kwargs: loss_fn=CrossEntropyLoss()
-#                eps=0.15
+#                eps=0.3
 #                nb_iter=40
 #                eps_iter=0.01
-#                rand_init=True
+#                rand_init=False
 #                clip_min=0.0
 #                clip_max=1.0
 #                targeted=False
 # data: mnist_test
 # model: mnist_lenet5_advtrained
 # accuracy: 98.64%
-# robust accuracy: 96.93%
+# attack success rate: 6.8%
+
 
 
 import torch.nn as nn
@@ -66,15 +67,15 @@ from advertorch.attacks import LinfPGDAttack
 # TODO: from advertorch.attacks import LinfMomentumIterativeAttack
 # TODO: from advertorch.attacks import FastFeatureAttack
 
-from advertorch_examples.benchmark_utils import benchmark_robust_accuracy
+from advertorch_examples.benchmark_utils import benchmark_attack_success_rate
 
 batch_size = 100
 device = "cuda"
 
 lst_attack = [
     (LinfPGDAttack, dict(
-        loss_fn=nn.CrossEntropyLoss(reduction="sum"), eps=0.15,
-        nb_iter=40, eps_iter=0.01, rand_init=True,
+        loss_fn=nn.CrossEntropyLoss(reduction="sum"), eps=0.3,
+        nb_iter=40, eps_iter=0.01, rand_init=False,
         clip_min=0.0, clip_max=1.0, targeted=False)),
 ]  # each element in the list is the tuple (attack_class, attack_kwargs)
 
@@ -93,7 +94,7 @@ info = get_benchmark_sys_info()
 lst_benchmark = []
 for model, loader in lst_setting:
     for attack_class, attack_kwargs in lst_attack:
-        lst_benchmark.append(benchmark_robust_accuracy(
+        lst_benchmark.append(benchmark_attack_success_rate(
             model, loader, attack_class, attack_kwargs))
 
 print(info)

--- a/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
@@ -1,0 +1,55 @@
+from advertorch_examples.utils import get_mnist_test_loader
+from advertorch_examples.utils import get_mnist_lenet5_clntrained
+from advertorch_examples.utils import get_mnist_lenet5_advtrained
+from advertorch_examples.benchmark_utils import get_benchmark_sys_info
+
+from advertorch.attacks import LinfPGDAttack
+# TODO: from advertorch.attacks import L2BasicIterativeAttack
+# TODO: from advertorch.attacks import LinfBasicIterativeAttack
+# TODO: from advertorch.attacks import PGDAttack
+# TODO: from advertorch.attacks import L2PGDAttack
+# TODO: from advertorch.attacks import L1PGDAttack
+# TODO: from advertorch.attacks import SparseL1DescentAttack
+# TODO: from advertorch.attacks import MomentumIterativeAttack
+# TODO: from advertorch.attacks import L2MomentumIterativeAttack
+# TODO: from advertorch.attacks import LinfMomentumIterativeAttack
+# TODO: from advertorch.attacks import FastFeatureAttack
+
+from advertorch_examples.benchmark_utils import benchmark_robust_accuracy
+# TODO: from advertorch_examples.benchmark_utils import benchmark_margin
+
+batch_size = 100
+device = "cuda"
+
+
+lst_attack = [
+    (LinfPGDAttack, {}),
+]
+# TODO: add dictionary values
+
+mnist_clntrained_model = get_mnist_lenet5_clntrained()
+mnist_clntrained_model.to(device)
+mnist_advtrained_model = get_mnist_lenet5_advtrained()
+mnist_advtrained_model.to(device)
+
+mnist_test_loader = get_mnist_test_loader(batch_size=batch_size)
+
+lst_setting = [
+    (mnist_clntrained_model, mnist_test_loader),
+    (mnist_advtrained_model, mnist_test_loader),
+]
+
+
+info = get_benchmark_sys_info()
+
+
+lst_benchmark = []
+
+for model, loader in lst_setting:
+    for attack_class, attack_kwargs in lst_attack:
+        lst_benchmark.append(benchmark_robust_accuracy(
+            model, loader, attack_class, attack_kwargs))
+
+print(info)
+for item in lst_benchmark:
+    print(item)

--- a/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_iterative_projected_gradient.py
@@ -1,3 +1,54 @@
+# Copyright (c) 2018-present, Royal Bank of Canada and other authors.
+# See the AUTHORS.txt file for a list of contributors.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#
+#
+# Automatically generated benchmark report (screen print of running this file)
+#
+# sysname: Linux
+# release: 4.4.0-140-generic
+# version: #166-Ubuntu SMP Wed Nov 14 20:09:47 UTC 2018
+# machine: x86_64
+# python: 3.7.3
+# torch: 1.1.0
+# torchvision: 0.3.0
+# advertorch: 0.1.5
+
+# attack type: LinfPGDAttack
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                eps=0.15
+#                nb_iter=40
+#                eps_iter=0.01
+#                rand_init=True
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test
+# model: mnist_lenet5_clntrained
+# accuracy: 98.89%
+# robust accuracy: 8.9%
+
+# attack type: LinfPGDAttack
+# attack kwargs: loss_fn=CrossEntropyLoss()
+#                eps=0.15
+#                nb_iter=40
+#                eps_iter=0.01
+#                rand_init=True
+#                clip_min=0.0
+#                clip_max=1.0
+#                targeted=False
+# data: mnist_test
+# model: mnist_lenet5_advtrained
+# accuracy: 98.64%
+# robust accuracy: 96.93%
+
+
+import torch.nn as nn
+
 from advertorch_examples.utils import get_mnist_test_loader
 from advertorch_examples.utils import get_mnist_lenet5_clntrained
 from advertorch_examples.utils import get_mnist_lenet5_advtrained
@@ -16,22 +67,19 @@ from advertorch.attacks import LinfPGDAttack
 # TODO: from advertorch.attacks import FastFeatureAttack
 
 from advertorch_examples.benchmark_utils import benchmark_robust_accuracy
-# TODO: from advertorch_examples.benchmark_utils import benchmark_margin
 
 batch_size = 100
 device = "cuda"
 
-
 lst_attack = [
-    (LinfPGDAttack, {}),
-]
-# TODO: add dictionary values
+    (LinfPGDAttack, dict(
+        loss_fn=nn.CrossEntropyLoss(reduction="sum"), eps=0.15,
+        nb_iter=40, eps_iter=0.01, rand_init=True,
+        clip_min=0.0, clip_max=1.0, targeted=False)),
+]  # each element in the list is the tuple (attack_class, attack_kwargs)
 
-mnist_clntrained_model = get_mnist_lenet5_clntrained()
-mnist_clntrained_model.to(device)
-mnist_advtrained_model = get_mnist_lenet5_advtrained()
-mnist_advtrained_model.to(device)
-
+mnist_clntrained_model = get_mnist_lenet5_clntrained().to(device)
+mnist_advtrained_model = get_mnist_lenet5_advtrained().to(device)
 mnist_test_loader = get_mnist_test_loader(batch_size=batch_size)
 
 lst_setting = [
@@ -42,9 +90,7 @@ lst_setting = [
 
 info = get_benchmark_sys_info()
 
-
 lst_benchmark = []
-
 for model, loader in lst_setting:
     for attack_class, attack_kwargs in lst_attack:
         lst_benchmark.append(benchmark_robust_accuracy(

--- a/advertorch_examples/attack_madry_et_al_models/attack_cifar10_challenge.py
+++ b/advertorch_examples/attack_madry_et_al_models/attack_cifar10_challenge.py
@@ -20,7 +20,7 @@ adversary = LinfPGDAttack(
     nb_iter=20, eps_iter=2. / 255, rand_init=False, clip_min=0.0, clip_max=1.0,
     targeted=False)
 
-label, pred, advpred = multiple_mini_batch_attack(
+label, pred, advpred, _ = multiple_mini_batch_attack(
     adversary, loader, device="cuda")
 
 print("Accuracy: {:.2f}%, Robust Accuracy: {:.2f}%".format(

--- a/advertorch_examples/attack_madry_et_al_models/attack_mnist_challenge.py
+++ b/advertorch_examples/attack_madry_et_al_models/attack_mnist_challenge.py
@@ -20,7 +20,7 @@ adversary = LinfPGDAttack(
     nb_iter=100, eps_iter=0.01, rand_init=False, clip_min=0.0, clip_max=1.0,
     targeted=False)
 
-label, pred, advpred = multiple_mini_batch_attack(
+label, pred, advpred, _ = multiple_mini_batch_attack(
     adversary, loader, device="cuda")
 
 print("Accuracy: {:.2f}%, Robust Accuracy: {:.2f}%".format(

--- a/advertorch_examples/benchmark_utils.py
+++ b/advertorch_examples/benchmark_utils.py
@@ -9,19 +9,21 @@ from advertorch.attacks.utils import multiple_mini_batch_attack
 
 
 def get_benchmark_sys_info():
-    rval = ""
+    rval = "#\n#\n"
+    rval += ("# Automatically generated benchmark report "
+             "(screen print of running this file)\n#\n")
     uname = os.uname()
-    rval += "sysname: {}\n".format(uname.sysname)
-    rval += "release: {}\n".format(uname.release)
-    rval += "version: {}\n".format(uname.version)
-    rval += "machine: {}\n".format(uname.machine)
-    rval += "python: {}.{}.{}\n".format(
+    rval += "# sysname: {}\n".format(uname.sysname)
+    rval += "# release: {}\n".format(uname.release)
+    rval += "# version: {}\n".format(uname.version)
+    rval += "# machine: {}\n".format(uname.machine)
+    rval += "# python: {}.{}.{}\n".format(
         sys.version_info.major,
         sys.version_info.minor,
         sys.version_info.micro)
-    rval += "torch: {}\n".format(torch.__version__)
-    rval += "torchvision: {}\n".format(torchvision.__version__)
-    rval += "advertorch: {}\n".format(advertorch.__version__)
+    rval += "# torch: {}\n".format(torch.__version__)
+    rval += "# torchvision: {}\n".format(torchvision.__version__)
+    rval += "# advertorch: {}\n".format(advertorch.__version__)
     return rval
 
 
@@ -34,11 +36,18 @@ def benchmark_robust_accuracy(
     robust_accuracy = 100. * (label == advpred).sum().item() / len(label)
 
     rval = ""
-    rval += "attack type: {}\n".format(attack_class.__name__)
-    rval += "attack kwargs: {}\n".format(str(attack_kwargs))
-    rval += "data: {}\n".format(loader.name)
-    rval += "model: {}\n".format(model.name)
-    rval += "accuracy: {}%\n".format(accuracy)
-    rval += "robust accuracy: {}%\n".format(robust_accuracy)
+    rval += "# attack type: {}\n".format(attack_class.__name__)
+
+    prefix = " attack kwargs: "
+    count = 0
+    for key in attack_kwargs:
+        this_prefix = prefix if count == 0 else " " * len(prefix)
+        count += 1
+        rval += "#{}{}={}\n".format(this_prefix, key, attack_kwargs[key])
+
+    rval += "# data: {}\n".format(loader.name)
+    rval += "# model: {}\n".format(model.name)
+    rval += "# accuracy: {}%\n".format(accuracy)
+    rval += "# robust accuracy: {}%\n".format(robust_accuracy)
 
     return rval

--- a/advertorch_examples/benchmark_utils.py
+++ b/advertorch_examples/benchmark_utils.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+import torch
+import torchvision
+
+import advertorch
+from advertorch.attacks.utils import multiple_mini_batch_attack
+
+
+def get_benchmark_sys_info():
+    rval = ""
+    uname = os.uname()
+    rval += "sysname: {}\n".format(uname.sysname)
+    rval += "release: {}\n".format(uname.release)
+    rval += "version: {}\n".format(uname.version)
+    rval += "machine: {}\n".format(uname.machine)
+    rval += "python: {}.{}.{}\n".format(
+        sys.version_info.major,
+        sys.version_info.minor,
+        sys.version_info.micro)
+    rval += "torch: {}\n".format(torch.__version__)
+    rval += "torchvision: {}\n".format(torchvision.__version__)
+    rval += "advertorch: {}\n".format(advertorch.__version__)
+    return rval
+
+
+def benchmark_robust_accuracy(
+        model, loader, attack_class, attack_kwargs, device="cuda"):
+    adversary = attack_class(model, **attack_kwargs)
+    label, pred, advpred = multiple_mini_batch_attack(
+        adversary, loader, device=device)
+    accuracy = 100. * (label == pred).sum().item() / len(label)
+    robust_accuracy = 100. * (label == advpred).sum().item() / len(label)
+
+    rval = ""
+    rval += "attack type: {}\n".format(attack_class.__name__)
+    rval += "attack kwargs: {}\n".format(str(attack_kwargs))
+    rval += "data: {}\n".format(loader.name)
+    rval += "model: {}\n".format(model.name)
+    rval += "accuracy: {}%\n".format(accuracy)
+    rval += "robust accuracy: {}%\n".format(robust_accuracy)
+
+    return rval

--- a/advertorch_examples/benchmark_utils.py
+++ b/advertorch_examples/benchmark_utils.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import numpy as np
 import torch
 import torchvision
 
@@ -35,7 +34,7 @@ def _calculate_benchmark_results(
         adversary, loader, device=device, norm=norm)
     accuracy = 100. * (label == pred).sum().item() / len(label)
     attack_success_rate = 100. * (label != advpred).sum().item() / len(label)
-    dist = None if dist is None else dist[label != advpred]
+    dist = None if dist is None else dist[label != advpred & label == pred]
     return accuracy, attack_success_rate, dist
 
 

--- a/advertorch_examples/benchmark_utils.py
+++ b/advertorch_examples/benchmark_utils.py
@@ -34,7 +34,7 @@ def _calculate_benchmark_results(
         adversary, loader, device=device, norm=norm)
     accuracy = 100. * (label == pred).sum().item() / len(label)
     attack_success_rate = 100. * (label != advpred).sum().item() / len(label)
-    dist = None if dist is None else dist[label != advpred & label == pred]
+    dist = None if dist is None else dist[(label != advpred) & (label == pred)]
     return accuracy, attack_success_rate, dist
 
 
@@ -78,7 +78,8 @@ def benchmark_margin(
         model, loader, attack_class, attack_kwargs, accuracy,
         attack_success_rate)
 
-    rval += "# Among successful attacks (L{} norm):\n".format(norm)
+    rval += "# Among successful attacks (L{} norm) ".format(norm) + \
+        "on correctly classified examples:\n"
     rval += "#    minimum distance: {:.4}\n".format(dist.min().item())
     rval += "#    median distance: {:.4}\n".format(dist.median().item())
     rval += "#    maximum distance: {:.4}\n".format(dist.max().item())

--- a/advertorch_examples/utils.py
+++ b/advertorch_examples/utils.py
@@ -77,7 +77,7 @@ def get_mnist_lenet5_clntrained():
     model.load_state_dict(
         torch.load(os.path.join(TRAINED_MODEL_PATH, filename)))
     model.eval()
-    model.name = "mnist_lenet5_clntrained"
+    model.name = "MNIST LeNet5 standard training"
     # TODO: also described where can you find this model, and how is it trained
     return model
 
@@ -88,7 +88,7 @@ def get_mnist_lenet5_advtrained():
     model.load_state_dict(
         torch.load(os.path.join(TRAINED_MODEL_PATH, filename)))
     model.eval()
-    model.name = "mnist_lenet5_advtrained"
+    model.name = "MNIST LeNet 5 PGD training according to Madry et al. 2018"
     # TODO: also described where can you find this model, and how is it trained
     return model
 

--- a/advertorch_examples/utils.py
+++ b/advertorch_examples/utils.py
@@ -19,6 +19,9 @@ import torch
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 
+from advertorch.test_utils import LeNet5
+
+
 ROOT_PATH = os.path.expanduser("~/.advertorch")
 DATA_PATH = os.path.join(ROOT_PATH, "data")
 MNIST_PATH = os.path.join(DATA_PATH, "mnist")
@@ -33,31 +36,61 @@ def mkdir(directory):
 
 
 def get_mnist_train_loader(batch_size, shuffle=True):
-    return torch.utils.data.DataLoader(
+    loader = torch.utils.data.DataLoader(
         datasets.MNIST(MNIST_PATH, train=True, download=True,
                        transform=transforms.ToTensor()),
         batch_size=batch_size, shuffle=shuffle)
+    loader.name = "mnist_train"
+    return loader
 
 
 def get_mnist_test_loader(batch_size, shuffle=False):
-    return torch.utils.data.DataLoader(
+    loader = torch.utils.data.DataLoader(
         datasets.MNIST(MNIST_PATH, train=False, download=True,
                        transform=transforms.ToTensor()),
         batch_size=batch_size, shuffle=shuffle)
+    loader.name = "mnist_test"
+    return loader
 
 
 def get_cifar10_train_loader(batch_size, shuffle=True):
-    return torch.utils.data.DataLoader(
+    loader = torch.utils.data.DataLoader(
         datasets.CIFAR10(CIFAR10_PATH, train=True, download=True,
                          transform=transforms.ToTensor()),
         batch_size=batch_size, shuffle=shuffle)
+    loader.name = "cifar10_train"
+    return loader
 
 
 def get_cifar10_test_loader(batch_size, shuffle=False):
-    return torch.utils.data.DataLoader(
+    loader = torch.utils.data.DataLoader(
         datasets.CIFAR10(CIFAR10_PATH, train=False, download=True,
                          transform=transforms.ToTensor()),
         batch_size=batch_size, shuffle=shuffle)
+    loader.name = "cifar10_test"
+    return loader
+
+
+def get_mnist_lenet5_clntrained():
+    filename = "mnist_lenet5_clntrained.pt"
+    model = LeNet5()
+    model.load_state_dict(
+        torch.load(os.path.join(TRAINED_MODEL_PATH, filename)))
+    model.eval()
+    model.name = "mnist_lenet5_clntrained"
+    # TODO: also described where can you find this model, and how is it trained
+    return model
+
+
+def get_mnist_lenet5_advtrained():
+    filename = "mnist_lenet5_advtrained.pt"
+    model = LeNet5()
+    model.load_state_dict(
+        torch.load(os.path.join(TRAINED_MODEL_PATH, filename)))
+    model.eval()
+    model.name = "mnist_lenet5_advtrained"
+    # TODO: also described where can you find this model, and how is it trained
+    return model
 
 
 def bchw2bhwc(x):


### PR DESCRIPTION
the file for benchmarking fab attack's performance, the actual addition is d961d5e , i.e., the file advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py

This change is made after merging the current master with the fab attack branch.

