### PR TITLE
some more fixes

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,3 +6,4 @@ Xiaomeng Jin <tracy.jin@mail.utoronto.ca>
 Laurent Meunier <laurent.meunier1995@gmail.com>
 Alexandre Araujo <alexandre.araujo@wavestone.com>
 Jérôme Rony <jerome.rony.1@etsmtl.net>
+Francesco Croce <francesco91.croce@gmail.com>

--- a/advertorch/attacks/fast_adaptive_boundary.py
+++ b/advertorch/attacks/fast_adaptive_boundary.py
@@ -203,7 +203,7 @@ class FABAttack(Attack, LabelMixin):
         c4 = (s[:, 0] + c < 0)
         c3 = ((d * w).sum(dim=1) + c > 0)
         c6 = c4.nonzero().squeeze()
-        c2 = ((1 - c4) * (1 - c3)).nonzero().squeeze()
+        c2 = ((1 - c4.float()) * (1 - c3.float())).nonzero().squeeze()
         c6 = self.check_shape(c6)
         c2 = self.check_shape(c2)
 

--- a/advertorch/attacks/utils.py
+++ b/advertorch/attacks/utils.py
@@ -100,10 +100,10 @@ def multiple_mini_batch_attack(
     lst_advpred = []
     lst_dist = []
 
-    if norm == "inf":
+    if norm in ["Linf", "inf"]:
         def dist_func(x, y):
             return (x - y).view(x.size(0), -1).max(dim=1)[0]
-    elif norm == 1 or norm == 2:
+    elif norm in ["L1", 1] or norm in ["L2", 2]:
         from advertorch.utils import _get_norm_batch
 
         def dist_func(x, y):

--- a/advertorch/attacks/utils.py
+++ b/advertorch/attacks/utils.py
@@ -100,10 +100,14 @@ def multiple_mini_batch_attack(
     lst_advpred = []
     lst_dist = []
 
-    if norm in ["Linf", "inf"]:
+    _norm_convert_dict = {"Linf": "inf", "L2": 2, "L1": 1}
+    if norm in _norm_convert_dict:
+        norm = _norm_convert_dict[norm]
+
+    if norm == "inf":
         def dist_func(x, y):
             return (x - y).view(x.size(0), -1).max(dim=1)[0]
-    elif norm in ["L1", 1] or norm in ["L2", 2]:
+    elif norm == 1 or norm == 2:
         from advertorch.utils import _get_norm_batch
 
         def dist_func(x, y):

--- a/advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py
@@ -49,12 +49,12 @@
 # model: MNIST LeNet5 standard training
 # accuracy: 98.89%
 # attack success rate: 100.0%
-# Among successful attacks (Linf norm) on correctly classified examples:
-#    minimum distance: 0.0002932
-#    median distance: 0.2769
-#    maximum distance: 0.7625
-#    average distance: 0.2842
-#    distance standard deviation: 0.1108
+# Among successful attacks (L2 norm) on correctly classified examples:
+#    minimum distance: 0.001726
+#    median distance: 1.423
+#    maximum distance: 3.01
+#    average distance: 1.412
+#    distance standard deviation: 0.4805
 
 # attack type: FABAttack
 # attack kwargs: norm=L1
@@ -68,12 +68,12 @@
 # model: MNIST LeNet5 standard training
 # accuracy: 98.89%
 # attack success rate: 99.55%
-# Among successful attacks (Linf norm) on correctly classified examples:
-#    minimum distance: 0.0
-#    median distance: 0.8945
-#    maximum distance: 1.0
-#    average distance: 0.7125
-#    distance standard deviation: 0.3402
+# Among successful attacks (L1 norm) on correctly classified examples:
+#    minimum distance: 0.007688
+#    median distance: 7.61
+#    maximum distance: 36.06
+#    average distance: 8.365
+#    distance standard deviation: 4.42
 
 # attack type: FABAttack
 # attack kwargs: norm=Linf
@@ -106,12 +106,12 @@
 # model: MNIST LeNet 5 PGD training according to Madry et al. 2018
 # accuracy: 98.64%
 # attack success rate: 98.35%
-# Among successful attacks (Linf norm) on correctly classified examples:
-#    minimum distance: 0.00102
-#    median distance: 0.1866
-#    maximum distance: 1.0
-#    average distance: 0.2137
-#    distance standard deviation: 0.1098
+# Among successful attacks (L2 norm) on correctly classified examples:
+#    minimum distance: 0.003942
+#    median distance: 3.04
+#    maximum distance: 19.92
+#    average distance: 3.205
+#    distance standard deviation: 1.311
 
 # attack type: FABAttack
 # attack kwargs: norm=L1
@@ -125,12 +125,13 @@
 # model: MNIST LeNet 5 PGD training according to Madry et al. 2018
 # accuracy: 98.64%
 # attack success rate: 94.33%
-# Among successful attacks (Linf norm) on correctly classified examples:
-#    minimum distance: 5.96e-08
-#    median distance: 0.3015
-#    maximum distance: 1.0
-#    average distance: 0.3246
-#    distance standard deviation: 0.1528
+# Among successful attacks (L1 norm) on correctly classified examples:
+#    minimum distance: 0.00622
+#    median distance: 112.8
+#    maximum distance: 441.9
+#    average distance: 114.6
+#    distance standard deviation: 52.85
+
 
 
 from advertorch_examples.utils import get_mnist_test_loader

--- a/advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py
+++ b/advertorch_examples/attack_benchmarks/benchmark_fast_adaptive_boundary.py
@@ -188,7 +188,8 @@ lst_benchmark = []
 for model, loader in lst_setting:
     for attack_class, attack_kwargs in lst_attack:
         lst_benchmark.append(benchmark_margin(
-            model, loader, attack_class, attack_kwargs, norm="inf"))
+            model, loader, attack_class, attack_kwargs,
+            norm=attack_kwargs["norm"]))
 
 print(info)
 for item in lst_benchmark:

--- a/advertorch_examples/benchmark_utils.py
+++ b/advertorch_examples/benchmark_utils.py
@@ -78,7 +78,7 @@ def benchmark_margin(
         model, loader, attack_class, attack_kwargs, accuracy,
         attack_success_rate)
 
-    rval += "# Among successful attacks (L{} norm) ".format(norm) + \
+    rval += "# Among successful attacks ({} norm) ".format(norm) + \
         "on correctly classified examples:\n"
     rval += "#    minimum distance: {:.4}\n".format(dist.min().item())
     rval += "#    median distance: {:.4}\n".format(dist.median().item())


### PR DESCRIPTION
@fra31  I actually meant to test L2 and L1 robustness, but wrongly specified the norm to be Linf in the benchmark test. Now it is fixed. Please have a look at the benchmark results again. Sorry for the inconvenience.

I also fixed a small problem (causing problems under pytorch 1.3) in the L2 attack, and added your name to the author’s list. I think this time it is really ready for merging.

Thanks again for the hard work.